### PR TITLE
Fix mktemp for test setup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,6 @@ name: check
 
 on:
   push:
-    branches: [ master, ci ]
   pull_request:
     branches: [ master ]
 

--- a/tests/create/create-archive.sh
+++ b/tests/create/create-archive.sh
@@ -3,7 +3,7 @@ set -e
 cd "$(dirname "$0")/../.."
 . tests/setup.sh
 
-dir="$(mktemp --directory --tmpdir="$TEST_ROOT" XXXXX)"
+dir=$(mktmp_dir_in_test_root)
 mkdir "$dir/root"
 touch "$dir/root/file1"
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 
-TEST_ROOT=$(mktemp --dir)
+mktmp_dir() {
+  mktemp -d
+}
+
+mktmp_dir_in_test_root() {
+  dir="$TEST_ROOT/dir-$RANDOM"
+  mkdir -p "$dir"
+  echo "$dir"
+}
+
+TEST_ROOT=$(mktmp_dir)
 PKGR_EXTRACT_ROOT=$TEST_ROOT/root
 mkdir -p "$PKGR_EXTRACT_ROOT"
 export PKGR_EXTRACT_ROOT
@@ -75,7 +85,7 @@ assert_grep() {
 create_test_tar() {
   local data
   local v
-  data="$(mktemp --directory --tmpdir="$TEST_ROOT" XXXXX)"
+  data="$(mktmp_dir_in_test_root)"
   mkdir -p "$data/root"
 
   for v in "$@" ; do
@@ -94,7 +104,7 @@ create_test_tar() {
 create_exclude_file() {
   local file
   local v
-  file="$(mktemp --tmpdir="$TEST_ROOT" XXXXX.skip)"
+  file="$TEST_ROOT/$RANDOM.skip"
   for v in "$@" ; do
     echo "root/$v" >> "$file"
   done


### PR DESCRIPTION
use `mktemp -d` (extract in helper function for explicitness) since
`--dir` is not implemented on all `mktemp`s

use `$RANDOM` as a random identifier and add `mktmp_dir_in_test_root` to
create a directory in the test directory (already a `mktemp -d`
directory) using `$RANDOM`

use `$TEST_ROOT/$RANDOM.skip` when creating a random skip file in the
test directory

fixes test setup issues on Mac and Alpine. partial fix for #4 
